### PR TITLE
Recognize std::byte when is under C++17.

### DIFF
--- a/detail/traits.hpp
+++ b/detail/traits.hpp
@@ -5,6 +5,8 @@ This code is written by kerukuro and released into public domain.
 #ifndef DIGESTPP_DETAIL_TRAITS_HPP
 #define DIGESTPP_DETAIL_TRAITS_HPP
 
+#include <cstddef> // needed for testing std::byte
+
 namespace digestpp
 {
 namespace detail
@@ -21,6 +23,9 @@ struct is_byte
 {
 	static const bool value = std::is_same<T, char>::value ||
 			std::is_same<T, signed char>::value ||
+#if (defined(_HAS_STD_BYTE) && _HAS_STD_BYTE) || (defined(__cpp_lib_byte) && __cpp_lib_byte >= 201603)
+			std::is_same<T, std::byte>::value ||
+#endif
 			std::is_same<T, unsigned char>::value;
 };
 


### PR DESCRIPTION
Fix #8 
