### PR TITLE
Remember to initialize all members.

### DIFF
--- a/algorithm/detail/blake2_provider.hpp
+++ b/algorithm/detail/blake2_provider.hpp
@@ -134,6 +134,7 @@ public:
 	{
 		pos = 0;
 		total = 0;
+		xoffset = 0;
 		squeezing = false;
 
 		blake2_functions::initH(H);

--- a/algorithm/detail/k12m14_provider.hpp
+++ b/algorithm/detail/k12m14_provider.hpp
@@ -41,6 +41,7 @@ public:
 	{
 		main.init();
 		pos = 0;
+		total = 0;
 		chunk = 0;
 		squeezing = false;
 	}

--- a/algorithm/detail/sha3_provider.hpp
+++ b/algorithm/detail/sha3_provider.hpp
@@ -139,6 +139,7 @@ public:
 	{
 		zero_memory(A);
 		pos = 0;
+		total = 0;
 	}
 
 	inline void update(const unsigned char* data, size_t len)

--- a/algorithm/detail/shake_provider.hpp
+++ b/algorithm/detail/shake_provider.hpp
@@ -81,6 +81,7 @@ public:
 	{
 		zero_memory(A);
 		pos = 0;
+		total = 0;
 		squeezing = false;
 		suffix = 0;
 


### PR DESCRIPTION
Some members variables are not initialized by the init() member method.