### PR TITLE
Prevent unused parameter warning

### DIFF
--- a/algorithm/detail/k12m14_provider.hpp
+++ b/algorithm/detail/k12m14_provider.hpp
@@ -86,6 +86,8 @@ public:
 
 	inline void transform(const unsigned char* data, uint64_t num_blks, size_t reallen)
 	{
+		(void)reallen;
+
 		for (uint64_t blk = 0; blk < num_blks; blk++)
 		{
 			if (!chunk)


### PR DESCRIPTION
This commit resolves warning messages from `-Wall -Wextra -pedantic -Werror -pedantic-errors` (when using GCC, Clang).