### PR TITLE
Warning fixed for unused variable.

### DIFF
--- a/hasher.hpp
+++ b/hasher.hpp
@@ -133,17 +133,14 @@ class hasher : public Mixin<HashProvider>
 	{
 		const int tmp_buffer_size = 10000;
 		unsigned char buffer[tmp_buffer_size];
-		size_t len = 0;
 		while (istr.read(reinterpret_cast<T*>(buffer), sizeof(buffer)))
 		{
 			provider.update(buffer, sizeof(buffer));
-			len += sizeof(buffer);
 		}
 		size_t gcount = istr.gcount();
 		if (gcount)
 		{
 			provider.update(buffer, gcount);
-			len += gcount;
 		}
 		return *this;
 	}


### PR DESCRIPTION
An unused variable (len) is removed to avoid noisy compiler warnings.